### PR TITLE
Added line for cancel alarm feature

### DIFF
--- a/Timer/Alarm.swift
+++ b/Timer/Alarm.swift
@@ -36,6 +36,7 @@ class Alarm: NSObject {
         alarmNotification.category = Alarm.categoryAlarm
         
         UIApplication.sharedApplication().scheduleLocalNotification(alarmNotification)
+        localNotification = alarmNotification
     }
     
     func cancel() {


### PR DESCRIPTION
@calebhicks Turns out the first time around there was a minor oversight and a line of code required to be able to cancel the local notification if the alarm is canceled was left off.
